### PR TITLE
feat: add developer assignment interface

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -19,10 +19,17 @@ type Assignment = {
 
 const runCols = ['anomalies', 'service', 'fastTrack'] as const;
 const titles: Record<string, string> = {
-  build: 'Build',
+  build: '✅🛠️ Build',
   anomalies: 'Anomalies',
   service: 'Service',
   fastTrack: 'Fast Track',
+};
+
+const columnClasses: Record<string, string> = {
+  build: 'build-column',
+  anomalies: 'anomalies-column',
+  service: 'service-column',
+  fastTrack: 'fastTrack-column',
 };
 
 function App() {
@@ -77,12 +84,24 @@ function App() {
   if (!data) {
     return <div>Loading...</div>;
   }
+  const totalDevelopers =
+    data.build.length +
+    data.run.anomalies.length +
+    data.run.service.length +
+    data.run.fastTrack.length;
 
   const renderList = (id: string, developers: Developer[]) => (
     <Droppable droppableId={id} key={id}>
       {(provided) => (
-        <div className="column" ref={provided.innerRef} {...provided.droppableProps}>
-          <h3>{titles[id]}</h3>
+        <div
+          className={`column ${columnClasses[id]}`}
+          ref={provided.innerRef}
+          {...provided.droppableProps}
+        >
+          <div className="column-header">
+            <h3>{titles[id]}</h3>
+            <span className="badge">{developers.length}</span>
+          </div>
           {developers.map((dev, index) => (
             <Draggable draggableId={dev.id} index={index} key={dev.id}>
               {(prov) => (
@@ -92,9 +111,9 @@ function App() {
                   {...prov.draggableProps}
                   {...prov.dragHandleProps}
                 >
-                  <div>{dev.name}</div>
-                  <div>
-                    Lead: <span className="lead-badge">{dev.lead}</span>
+                  <div className="developer-name">👤 {dev.name}</div>
+                  <div className="developer-lead">
+                    👑 Lead: <span className="lead-badge">{dev.lead}</span>
                   </div>
                 </div>
               )}
@@ -108,12 +127,18 @@ function App() {
 
   return (
     <>
-      <h1>Team assignments</h1>
+      <header className="header">
+        <div>
+          <h1>Affectation des Développeurs</h1>
+          <p>Gérez les affectations entre les équipes Build et Run</p>
+        </div>
+        <div className="total">Total développeurs : {totalDevelopers}</div>
+      </header>
       <DragDropContext onDragEnd={handleDragEnd}>
         <div className="board">
           {renderList('build', data.build)}
           <div className="run">
-            <h2>Run</h2>
+            <h2>⚙️ Run</h2>
             <div className="run-columns">
               {runCols.map((col) => renderList(col, data.run[col]))}
             </div>

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -4,6 +4,28 @@ body {
   padding: 0;
 }
 
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem;
+  background: #f5f5f5;
+}
+
+.header h1 {
+  margin: 0;
+}
+
+.header p {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #555;
+}
+
+.total {
+  font-weight: bold;
+}
+
 .board {
   display: flex;
   gap: 1rem;
@@ -17,6 +39,36 @@ body {
   padding: 0.5rem;
   min-width: 250px;
   flex: 1;
+}
+
+.column-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.badge {
+  background: #333;
+  color: #fff;
+  padding: 2px 8px;
+  border-radius: 12px;
+  font-size: 0.75rem;
+}
+
+.build-column {
+  background: #eafaf1;
+}
+
+.anomalies-column {
+  background: #fde8e8;
+}
+
+.service-column {
+  background: #e8f4fd;
+}
+
+.fastTrack-column {
+  background: #f3e8fd;
 }
 
 .column h2 {
@@ -59,6 +111,7 @@ body {
 
 .run-columns {
   display: flex;
+  flex-direction: column;
   gap: 1rem;
   flex: 1;
 }

--- a/data/affectations.json
+++ b/data/affectations.json
@@ -1,13 +1,18 @@
 {
   "build": [
-    {"id": "dev1", "name": "Alice", "lead": "Bob"},
-    {"id": "dev2", "name": "Charlie", "lead": "Dana"}
+    { "id": "dev1", "name": "Alice Martin", "lead": "Sophie Dubois" },
+    { "id": "dev2", "name": "Thomas Bernard", "lead": "Sophie Dubois" }
   ],
   "run": {
     "anomalies": [
-      {"id": "dev3", "name": "Eve", "lead": "Frank"}
+      { "id": "dev3", "name": "Marie Leroy", "lead": "Pierre Moreau" }
     ],
-    "service": [],
-    "fastTrack": []
+    "service": [
+      { "id": "dev4", "name": "Lucas Petit", "lead": "Pierre Moreau" },
+      { "id": "dev5", "name": "Emma Roux", "lead": "Julie Martin" }
+    ],
+    "fastTrack": [
+      { "id": "dev6", "name": "Hugo Blanc", "lead": "Julie Martin" }
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- implement developer assignment board with Build and Run columns
- style cards with team badges and header showing developer totals
- seed data with six developers across Build and Run teams

## Testing
- `cd client && npm test`
- `cd ../server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894dc31fde4832da3618ab0b16a1b79