### PR TITLE
Enable real-time assignment updates with SSE

### DIFF
--- a/client/src/behavior/useAssignments.ts
+++ b/client/src/behavior/useAssignments.ts
@@ -9,6 +9,9 @@ export const useAssignments = () => {
 
   useEffect(() => {
     getAssignments().then(setData);
+    const source = new EventSource('/events');
+    source.onmessage = (e) => setData(JSON.parse(e.data));
+    return () => source.close();
   }, []);
 
   const handleDragEnd = (result: DropResult) => {

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -5,7 +5,11 @@ export default defineConfig({
   server: {
     port: 3000,
     proxy: {
-      '/affectations': 'http://localhost:3001'
+      '/affectations': 'http://localhost:3001',
+      '/events': {
+        target: 'http://localhost:3001',
+        changeOrigin: true,
+      }
     }
   },
   plugins: [react()]

--- a/server/index.js
+++ b/server/index.js
@@ -7,9 +7,31 @@ const path = require('path');
 const app = express();
 const PORT = 3001;
 const DATA_FILE = path.join(__dirname, '../data/affectations.json');
+const clients = [];
 
 app.use(cors());
 app.use(bodyParser.json());
+
+// Server-Sent Events endpoint
+app.get('/events', async (req, res) => {
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+  res.setHeader('Connection', 'keep-alive');
+
+  clients.push(res);
+
+  req.on('close', () => {
+    const index = clients.indexOf(res);
+    if (index !== -1) clients.splice(index, 1);
+  });
+
+  try {
+    const data = await fs.readFile(DATA_FILE, 'utf-8');
+    res.write(`data: ${data}\n\n`);
+  } catch (err) {
+    // ignore read errors for initial send
+  }
+});
 
 app.get('/affectations', async (req, res) => {
   try {
@@ -24,6 +46,8 @@ app.post('/affectations', async (req, res) => {
   try {
     await fs.writeFile(DATA_FILE, JSON.stringify(req.body, null, 2));
     res.json({ status: 'ok' });
+    const payload = JSON.stringify(req.body);
+    clients.forEach((client) => client.write(`data: ${payload}\n\n`));
   } catch (err) {
     res.status(500).json({ error: 'Could not save data' });
   }


### PR DESCRIPTION
## Summary
- add Server-Sent Events endpoint and broadcasting in backend
- subscribe to updates on frontend via EventSource and proxy /events

## Testing
- `cd server && npm test`
- `cd client && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899ce65a3d4832da55200cd6b4011a3