### PR TITLE
Add Docker configuration to run client and server together

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+client/node_modules
+server/node_modules
+client/dist
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# Build stage
+FROM node:18-alpine AS build
+
+WORKDIR /app
+
+# Install and build client
+COPY client/package*.json ./client/
+RUN cd client && npm install
+COPY client ./client
+RUN cd client && npm run build
+
+# Install server dependencies
+COPY server/package*.json ./server/
+RUN cd server && npm install
+COPY server ./server
+COPY data ./data
+
+# Production stage
+FROM node:18-alpine
+
+WORKDIR /app
+
+COPY --from=build /app/server ./server
+COPY --from=build /app/data ./data
+COPY --from=build /app/client/dist ./client/dist
+
+WORKDIR /app/server
+
+EXPOSE 3001
+
+CMD ["node", "index.js"]

--- a/README.md
+++ b/README.md
@@ -29,3 +29,14 @@ npm run dev
 ```
 
 The client runs on `http://localhost:3000` and proxies API requests to the server on `http://localhost:3001`.
+
+## Running with Docker
+
+Build the image and start the application:
+
+```
+docker build -t game-hub .
+docker run -p 3001:3001 game-hub
+```
+
+Then open `http://localhost:3001` in your browser.

--- a/server/index.js
+++ b/server/index.js
@@ -5,11 +5,13 @@ const fs = require('fs').promises;
 const path = require('path');
 
 const app = express();
-const PORT = 3001;
+const PORT = process.env.PORT || 3001;
 const DATA_FILE = path.join(__dirname, '../data/affectations.json');
+const CLIENT_BUILD_PATH = path.join(__dirname, '../client/dist');
 
 app.use(cors());
 app.use(bodyParser.json());
+app.use(express.static(CLIENT_BUILD_PATH));
 
 app.get('/affectations', async (req, res) => {
   try {
@@ -27,6 +29,10 @@ app.post('/affectations', async (req, res) => {
   } catch (err) {
     res.status(500).json({ error: 'Could not save data' });
   }
+});
+
+app.get('*', (req, res) => {
+  res.sendFile(path.join(CLIENT_BUILD_PATH, 'index.html'));
 });
 
 app.listen(PORT, () => {


### PR DESCRIPTION
## Summary
- serve built client from Express server and allow PORT override
- add multi-stage Dockerfile and dockerignore for combined deployment
- document Docker usage in README

## Testing
- `npm test` in `server`
- `npm test` in `client`
- `docker build -t game-hub:test .` *(fails: command not found)*
- `apt-get update` *(fails: repository '... InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6899ceaca36c832d927386a456564520