### PR TITLE
Add 'Libre' section and standardize developer card width

### DIFF
--- a/client/src/behavior/constants.ts
+++ b/client/src/behavior/constants.ts
@@ -5,6 +5,7 @@ export const titles: Record<string, string> = {
   anomalies: 'Anomalies',
   service: 'Service',
   fastTrack: 'Fast Track',
+  free: 'Libre',
 };
 
 export const columnClasses: Record<string, string> = {
@@ -12,4 +13,5 @@ export const columnClasses: Record<string, string> = {
   anomalies: 'anomalies-column',
   service: 'service-column',
   fastTrack: 'fastTrack-column',
+  free: 'free-column',
 };

--- a/client/src/behavior/useAssignments.ts
+++ b/client/src/behavior/useAssignments.ts
@@ -13,13 +13,21 @@ export const useAssignments = () => {
 
   const handleDragEnd = (result: DropResult) => {
     if (!result.destination || !data) return;
-    const sourceId = result.source.droppableId as keyof Assignment['run'] | 'build';
-    const destId = result.destination.droppableId as keyof Assignment['run'] | 'build';
+    const sourceId = result.source.droppableId as keyof Assignment['run'] | 'build' | 'free';
+    const destId = result.destination.droppableId as keyof Assignment['run'] | 'build' | 'free';
 
     const sourceList =
-      sourceId === 'build' ? [...data.build] : [...data.run[sourceId]];
+      sourceId === 'build'
+        ? [...data.build]
+        : sourceId === 'free'
+        ? [...data.free]
+        : [...data.run[sourceId]];
     const destList =
-      destId === 'build' ? [...data.build] : [...data.run[destId]];
+      destId === 'build'
+        ? [...data.build]
+        : destId === 'free'
+        ? [...data.free]
+        : [...data.run[destId]];
 
     const [moved] = sourceList.splice(result.source.index, 1);
     destList.splice(result.destination.index, 0, moved);
@@ -47,6 +55,12 @@ export const useAssignments = () => {
             ? destList
             : data.run.fastTrack,
       },
+      free:
+        sourceId === 'free'
+          ? sourceList
+          : destId === 'free'
+          ? destList
+          : data.free,
     };
     setData(newData);
     saveAssignments(newData).then(() => {
@@ -60,7 +74,8 @@ export const useAssignments = () => {
       ? data.build.length +
         data.run.anomalies.length +
         data.run.service.length +
-        data.run.fastTrack.length
+        data.run.fastTrack.length +
+        data.free.length
       : 0;
 
   return { data, saved, handleDragEnd, totalDevelopers };

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -71,6 +71,14 @@ body {
   background: #f3e8fd;
 }
 
+.free-section {
+  padding: 0 1rem 1rem;
+}
+
+.free-column {
+  background: #fffbea;
+}
+
 .column h2 {
   text-align: center;
 }
@@ -81,6 +89,7 @@ body {
   border-radius: 4px;
   padding: 0.5rem;
   margin-bottom: 0.5rem;
+  width: 350px;
 }
 
 .lead-badge {

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -11,4 +11,5 @@ export type Assignment = {
     service: Developer[];
     fastTrack: Developer[];
   };
+  free: Developer[];
 };

--- a/client/src/ui/App.tsx
+++ b/client/src/ui/App.tsx
@@ -65,6 +65,7 @@ function App() {
             </div>
           </div>
         </div>
+        <div className="free-section">{renderList('free', data.free)}</div>
       </DragDropContext>
       {saved && <div className="success">Sauvegarde réussie</div>}
     </>

--- a/data/affectations.json
+++ b/data/affectations.json
@@ -14,5 +14,6 @@
     "fastTrack": [
       { "id": "dev6", "name": "Hugo Blanc", "lead": "Julie Martin" }
     ]
-  }
+  },
+  "free": []
 }


### PR DESCRIPTION
## Summary
- Add a new "Libre" section to manage unassigned developers and extend assignment logic accordingly
- Introduce styling for "Libre" and fix developer card width to 350px
- Update data model and sample data to support unassigned developers

## Testing
- `npm test` (client)
- `npm test` (server)`

------
https://chatgpt.com/codex/tasks/task_e_6899d04f4164832daaca97996fb9fb5b