### PR TITLE
feat: add responsive multi-column developer sections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,9 @@ buildNumber.properties
 .project
 # JDT-specific (Eclipse Java Development Tools)
 .classpath
+
+# Node.js dependencies and lockfiles
+client/node_modules/
+client/package-lock.json
+server/node_modules/
+server/package-lock.json

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -83,13 +83,41 @@ body {
   text-align: center;
 }
 
+.developer-list {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.build-column .developer-list,
+.anomalies-column .developer-list,
+.service-column .developer-list,
+.fastTrack-column .developer-list {
+  grid-template-columns: repeat(2, 1fr);
+}
+
+.free-column .developer-list {
+  grid-template-columns: repeat(4, 1fr);
+}
+
 .developer-card {
   background: white;
   border: 1px solid #ccc;
   border-radius: 4px;
   padding: 0.5rem;
-  margin-bottom: 0.5rem;
-  width: 350px;
+  width: 100%;
+}
+
+@media (max-width: 600px) {
+  .build-column .developer-list,
+  .anomalies-column .developer-list,
+  .service-column .developer-list,
+  .fastTrack-column .developer-list {
+    grid-template-columns: 1fr;
+  }
+
+  .free-column .developer-list {
+    grid-template-columns: repeat(2, 1fr);
+  }
 }
 
 .lead-badge {

--- a/client/src/ui/App.tsx
+++ b/client/src/ui/App.tsx
@@ -23,24 +23,26 @@ function App() {
             <h3>{titles[id]}</h3>
             <span className="badge">{developers.length}</span>
           </div>
-          {developers.map((dev, index) => (
-            <Draggable draggableId={dev.id} index={index} key={dev.id}>
-              {(prov) => (
-                <div
-                  className="developer-card"
-                  ref={prov.innerRef}
-                  {...prov.draggableProps}
-                  {...prov.dragHandleProps}
-                >
-                  <div className="developer-name">👤 {dev.name}</div>
-                  <div className="developer-lead">
-                    👑 Lead: <span className="lead-badge">{dev.lead}</span>
+          <div className="developer-list">
+            {developers.map((dev, index) => (
+              <Draggable draggableId={dev.id} index={index} key={dev.id}>
+                {(prov) => (
+                  <div
+                    className="developer-card"
+                    ref={prov.innerRef}
+                    {...prov.draggableProps}
+                    {...prov.dragHandleProps}
+                  >
+                    <div className="developer-name">👤 {dev.name}</div>
+                    <div className="developer-lead">
+                      👑 Lead: <span className="lead-badge">{dev.lead}</span>
+                    </div>
                   </div>
-                </div>
-              )}
-            </Draggable>
-          ))}
-          {provided.placeholder}
+                )}
+              </Draggable>
+            ))}
+            {provided.placeholder}
+          </div>
         </div>
       )}
     </Droppable>


### PR DESCRIPTION
## Summary
- display build and run assignments in two-column grids
- show free developers in four columns and adapt layout for mobile
- ignore node modules in version control

## Testing
- `cd client && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899d2dd9ce8832d9eec08f1c14c7478