### PR TITLE
Add browser notifications for assignment updates

### DIFF
--- a/client/src/behavior/useAssignments.ts
+++ b/client/src/behavior/useAssignments.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { DropResult } from '@hello-pangea/dnd';
 import { Assignment } from '../types';
 import { getAssignments, saveAssignments } from '../services/assignmentService';
+import { sendNotification } from '../services/notificationService';
 
 export const useAssignments = () => {
   const [data, setData] = useState<Assignment | null>(null);
@@ -66,6 +67,7 @@ export const useAssignments = () => {
     saveAssignments(newData).then(() => {
       setSaved(true);
       setTimeout(() => setSaved(false), 2000);
+      sendNotification();
     });
   };
 

--- a/client/src/services/notificationService.ts
+++ b/client/src/services/notificationService.ts
@@ -1,0 +1,20 @@
+let eventSource: EventSource | null = null;
+const clientId = Math.random().toString(36).slice(2);
+
+const getEventSource = () => {
+  if (!eventSource) {
+    eventSource = new EventSource(`/events?id=${clientId}`);
+  }
+  return eventSource;
+};
+
+export const sendNotification = () => {
+  fetch(`/notify?id=${clientId}`, { method: 'POST' });
+};
+
+export const subscribeNotifications = (onMessage: () => void) => {
+  const es = getEventSource();
+  const handler = () => onMessage();
+  es.addEventListener('message', handler);
+  return () => es.removeEventListener('message', handler);
+};

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -140,6 +140,21 @@ body {
   border-radius: 4px;
 }
 
+.notif-btn {
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+}
+
+.notification {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  background: #ffc107;
+  color: #000;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+}
+
 .run {
   flex: 1;
   display: flex;

--- a/client/src/ui/App.tsx
+++ b/client/src/ui/App.tsx
@@ -1,11 +1,25 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { DragDropContext, Droppable, Draggable } from '@hello-pangea/dnd';
 import { useAssignments } from '../behavior/useAssignments';
 import { runCols, titles, columnClasses } from '../behavior/constants';
 import { Developer } from '../types';
+import { sendNotification, subscribeNotifications } from '../services/notificationService';
 
 function App() {
   const { data, saved, handleDragEnd, totalDevelopers } = useAssignments();
+  const [notification, setNotification] = useState(false);
+
+  useEffect(() => {
+    const unsub = subscribeNotifications(() => setNotification(true));
+    return unsub;
+  }, []);
+
+  useEffect(() => {
+    if (notification) {
+      const timer = setTimeout(() => setNotification(false), 3000);
+      return () => clearTimeout(timer);
+    }
+  }, [notification]);
 
   if (!data) {
     return <div>Loading...</div>;
@@ -55,6 +69,9 @@ function App() {
           <h1>Affectation des Développeurs</h1>
           <p>Gérez les affectations entre les équipes Build et Run</p>
         </div>
+        <button className="notif-btn" onClick={() => sendNotification()}>
+          send notif
+        </button>
         <div className="total">Total développeurs : {totalDevelopers}</div>
       </header>
       <DragDropContext onDragEnd={handleDragEnd}>
@@ -70,6 +87,9 @@ function App() {
         <div className="free-section">{renderList('free', data.free)}</div>
       </DragDropContext>
       {saved && <div className="success">Sauvegarde réussie</div>}
+      {notification && (
+        <div className="notification">Modification effectuée par un autre utilisateur</div>
+      )}
     </>
   );
 }

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -5,7 +5,9 @@ export default defineConfig({
   server: {
     port: 3000,
     proxy: {
-      '/affectations': 'http://localhost:3001'
+      '/affectations': 'http://localhost:3001',
+      '/notify': 'http://localhost:3001',
+      '/events': 'http://localhost:3001'
     }
   },
   plugins: [react()]


### PR DESCRIPTION
## Summary
- use Server-Sent Events to broadcast updates from the server
- notify users of remote changes and add a `send notif` test button
- style notification banner and button

## Testing
- `npm test` (server)
- `npm test` (client)


------
https://chatgpt.com/codex/tasks/task_e_6899de446d2c832dad9ef84dc08234a3