### PR TITLE
Enforce page reload via persistent notification overlay

### DIFF
--- a/client/src/style.css
+++ b/client/src/style.css
@@ -147,12 +147,23 @@ body {
 
 .notification {
   position: fixed;
-  top: 1rem;
-  right: 1rem;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 1000;
+}
+
+.notification-message {
   background: #ffc107;
   color: #000;
-  padding: 0.5rem 1rem;
+  padding: 1rem;
   border-radius: 4px;
+  cursor: pointer;
 }
 
 .run {

--- a/client/src/ui/App.tsx
+++ b/client/src/ui/App.tsx
@@ -14,12 +14,6 @@ function App() {
     return unsub;
   }, []);
 
-  useEffect(() => {
-    if (notification) {
-      const timer = setTimeout(() => setNotification(false), 3000);
-      return () => clearTimeout(timer);
-    }
-  }, [notification]);
 
   if (!data) {
     return <div>Loading...</div>;
@@ -88,7 +82,15 @@ function App() {
       </DragDropContext>
       {saved && <div className="success">Sauvegarde réussie</div>}
       {notification && (
-        <div className="notification">Modification effectuée par un autre utilisateur</div>
+        <div className="notification">
+          <div
+            className="notification-message"
+            onClick={() => window.location.reload()}
+          >
+            Modification effectuée par un autre utilisateur - Cliquez pour
+            recharger
+          </div>
+        </div>
       )}
     </>
   );


### PR DESCRIPTION
## Summary
- center notification as full-screen overlay
- require user click to reload, removing auto-dismiss

## Testing
- `cd client && npm test`
- `cd server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899ecd3e1a8832db8652323460c83f2