### PR TITLE
feat: refactor layout into kanban columns

### DIFF
--- a/client/src/style.css
+++ b/client/src/style.css
@@ -72,11 +72,13 @@ body {
 }
 
 .free-section {
-  padding: 0 1rem 1rem;
+  padding: 1rem;
 }
 
 .free-column {
   background: #fffbea;
+  border-radius: 4px;
+  padding: 0.5rem;
 }
 
 .column h2 {
@@ -155,19 +157,3 @@ body {
   border-radius: 4px;
 }
 
-.run {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-}
-
-.run-columns {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  flex: 1;
-}
-
-.run-columns .column {
-  min-width: 0;
-}

--- a/client/src/ui/App.tsx
+++ b/client/src/ui/App.tsx
@@ -29,7 +29,7 @@ function App() {
     <Droppable droppableId={id} key={id}>
       {(provided) => (
         <div
-          className={`column ${columnClasses[id]}`}
+          className={id === 'free' ? columnClasses[id] : `column ${columnClasses[id]}`}
           ref={provided.innerRef}
           {...provided.droppableProps}
         >
@@ -75,16 +75,11 @@ function App() {
         <div className="total">Total développeurs : {totalDevelopers}</div>
       </header>
       <DragDropContext onDragEnd={handleDragEnd}>
+        <div className="free-section">{renderList('free', data.free)}</div>
         <div className="board">
           {renderList('build', data.build)}
-          <div className="run">
-            <h2>⚙️ Run</h2>
-            <div className="run-columns">
-              {runCols.map((col) => renderList(col, data.run[col]))}
-            </div>
-          </div>
+          {runCols.map((col) => renderList(col, data.run[col]))}
         </div>
-        <div className="free-section">{renderList('free', data.free)}</div>
       </DragDropContext>
       {saved && <div className="success">Sauvegarde réussie</div>}
       {notification && (


### PR DESCRIPTION
## Summary
- move free developer list to a top section
- display build and run categories as side-by-side kanban columns

## Testing
- `cd client && npm test`
- `cd server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b291b0894832d9b501e3f8473ed9e