### PR TITLE
Refactor UI into modular components

### DIFF
--- a/client/src/ui/App.tsx
+++ b/client/src/ui/App.tsx
@@ -1,9 +1,11 @@
 import React, { useEffect, useState } from 'react';
-import { DragDropContext, Droppable, Draggable } from '@hello-pangea/dnd';
+import { DragDropContext } from '@hello-pangea/dnd';
 import { useAssignments } from '../behavior/useAssignments';
-import { runCols, titles, columnClasses } from '../behavior/constants';
-import { Developer } from '../types';
 import { sendNotification, subscribeNotifications } from '../services/notificationService';
+import Header from './components/Header';
+import Board from './components/Board/Board';
+import FreeSection from './components/Board/FreeSection';
+import Notification from './components/Notification';
 
 function App() {
   const { data, saved, handleDragEnd, totalDevelopers } = useAssignments();
@@ -25,71 +27,21 @@ function App() {
     return <div>Loading...</div>;
   }
 
-  const renderList = (id: string, developers: Developer[]) => (
-    <Droppable droppableId={id} key={id}>
-      {(provided) => (
-        <div
-          className={`column ${columnClasses[id]}`}
-          ref={provided.innerRef}
-          {...provided.droppableProps}
-        >
-          <div className="column-header">
-            <h3>{titles[id]}</h3>
-            <span className="badge">{developers.length}</span>
-          </div>
-          <div className="developer-list">
-            {developers.map((dev, index) => (
-              <Draggable draggableId={dev.id} index={index} key={dev.id}>
-                {(prov) => (
-                  <div
-                    className="developer-card"
-                    ref={prov.innerRef}
-                    {...prov.draggableProps}
-                    {...prov.dragHandleProps}
-                  >
-                    <div className="developer-name">👤 {dev.name}</div>
-                    <div className="developer-lead">
-                      👑 Lead: <span className="lead-badge">{dev.lead}</span>
-                    </div>
-                  </div>
-                )}
-              </Draggable>
-            ))}
-            {provided.placeholder}
-          </div>
-        </div>
-      )}
-    </Droppable>
-  );
-
   return (
     <>
-      <header className="header">
-        <div>
-          <h1>Affectation des Développeurs</h1>
-          <p>Gérez les affectations entre les équipes Build et Run</p>
-        </div>
-        <button className="notif-btn" onClick={() => sendNotification()}>
-          send notif
-        </button>
-        <div className="total">Total développeurs : {totalDevelopers}</div>
-      </header>
+      <Header
+        totalDevelopers={totalDevelopers}
+        onSendNotification={sendNotification}
+      />
       <DragDropContext onDragEnd={handleDragEnd}>
-        <div className="board">
-          {renderList('build', data.build)}
-          <div className="run">
-            <h2>⚙️ Run</h2>
-            <div className="run-columns">
-              {runCols.map((col) => renderList(col, data.run[col]))}
-            </div>
-          </div>
-        </div>
-        <div className="free-section">{renderList('free', data.free)}</div>
+        <Board build={data.build} run={data.run} />
+        <FreeSection developers={data.free} />
       </DragDropContext>
       {saved && <div className="success">Sauvegarde réussie</div>}
-      {notification && (
-        <div className="notification">Modification effectuée par un autre utilisateur</div>
-      )}
+      <Notification
+        visible={notification}
+        message="Modification effectuée par un autre utilisateur"
+      />
     </>
   );
 }

--- a/client/src/ui/components/Board/Board.tsx
+++ b/client/src/ui/components/Board/Board.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Assignment } from '../../../types';
+import BuildColumn from './BuildColumn';
+import RunSection from './RunSection';
+
+interface BoardProps {
+  build: Assignment['build'];
+  run: Assignment['run'];
+}
+
+function Board({ build, run }: BoardProps) {
+  return (
+    <div className="board">
+      <BuildColumn developers={build} />
+      <RunSection run={run} />
+    </div>
+  );
+}
+
+export default Board;

--- a/client/src/ui/components/Board/BuildColumn.tsx
+++ b/client/src/ui/components/Board/BuildColumn.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Developer } from '../../../types';
+import { titles, columnClasses } from '../../../behavior/constants';
+import Column from '../Column';
+
+interface BuildColumnProps {
+  developers: Developer[];
+}
+
+function BuildColumn({ developers }: BuildColumnProps) {
+  return (
+    <Column
+      id="build"
+      title={titles.build}
+      className={columnClasses.build}
+      developers={developers}
+    />
+  );
+}
+
+export default BuildColumn;

--- a/client/src/ui/components/Board/FreeSection.tsx
+++ b/client/src/ui/components/Board/FreeSection.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Developer } from '../../../types';
+import { titles, columnClasses } from '../../../behavior/constants';
+import Column from '../Column';
+
+interface FreeSectionProps {
+  developers: Developer[];
+}
+
+function FreeSection({ developers }: FreeSectionProps) {
+  return (
+    <div className="free-section">
+      <Column
+        id="free"
+        title={titles.free}
+        className={columnClasses.free}
+        developers={developers}
+      />
+    </div>
+  );
+}
+
+export default FreeSection;

--- a/client/src/ui/components/Board/RunColumn.tsx
+++ b/client/src/ui/components/Board/RunColumn.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Assignment, Developer } from '../../../types';
+import { titles, columnClasses } from '../../../behavior/constants';
+import Column from '../Column';
+
+interface RunColumnProps {
+  id: keyof Assignment['run'];
+  developers: Developer[];
+}
+
+function RunColumn({ id, developers }: RunColumnProps) {
+  return (
+    <Column
+      id={id}
+      title={titles[id]}
+      className={columnClasses[id]}
+      developers={developers}
+    />
+  );
+}
+
+export default RunColumn;

--- a/client/src/ui/components/Board/RunSection.tsx
+++ b/client/src/ui/components/Board/RunSection.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Assignment } from '../../../types';
+import { runCols } from '../../../behavior/constants';
+import RunColumn from './RunColumn';
+
+interface RunSectionProps {
+  run: Assignment['run'];
+}
+
+function RunSection({ run }: RunSectionProps) {
+  return (
+    <div className="run">
+      <h2>⚙️ Run</h2>
+      <div className="run-columns">
+        {runCols.map((col) => (
+          <RunColumn key={col} id={col} developers={run[col]} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default RunSection;

--- a/client/src/ui/components/Column.tsx
+++ b/client/src/ui/components/Column.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Droppable } from '@hello-pangea/dnd';
+import { Developer } from '../../types';
+import DeveloperCard from './DeveloperCard';
+
+interface ColumnProps {
+  id: string;
+  title: string;
+  developers: Developer[];
+  className?: string;
+}
+
+function Column({ id, title, developers, className }: ColumnProps) {
+  return (
+    <Droppable droppableId={id} key={id}>
+      {(provided) => (
+        <div
+          className={`column ${className ?? ''}`}
+          ref={provided.innerRef}
+          {...provided.droppableProps}
+        >
+          <div className="column-header">
+            <h3>{title}</h3>
+            <span className="badge">{developers.length}</span>
+          </div>
+          <div className="developer-list">
+            {developers.map((dev, index) => (
+              <DeveloperCard developer={dev} index={index} key={dev.id} />
+            ))}
+            {provided.placeholder}
+          </div>
+        </div>
+      )}
+    </Droppable>
+  );
+}
+
+export default Column;

--- a/client/src/ui/components/DeveloperCard.tsx
+++ b/client/src/ui/components/DeveloperCard.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Draggable } from '@hello-pangea/dnd';
+import { Developer } from '../../types';
+
+interface DeveloperCardProps {
+  developer: Developer;
+  index: number;
+}
+
+function DeveloperCard({ developer, index }: DeveloperCardProps) {
+  return (
+    <Draggable draggableId={developer.id} index={index}>
+      {(prov) => (
+        <div
+          className="developer-card"
+          ref={prov.innerRef}
+          {...prov.draggableProps}
+          {...prov.dragHandleProps}
+        >
+          <div className="developer-name">👤 {developer.name}</div>
+          <div className="developer-lead">
+            👑 Lead: <span className="lead-badge">{developer.lead}</span>
+          </div>
+        </div>
+      )}
+    </Draggable>
+  );
+}
+
+export default DeveloperCard;

--- a/client/src/ui/components/Header.tsx
+++ b/client/src/ui/components/Header.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+interface HeaderProps {
+  totalDevelopers: number;
+  onSendNotification: () => void;
+}
+
+function Header({ totalDevelopers, onSendNotification }: HeaderProps) {
+  return (
+    <header className="header">
+      <div>
+        <h1>Affectation des Développeurs</h1>
+        <p>Gérez les affectations entre les équipes Build et Run</p>
+      </div>
+      <button className="notif-btn" onClick={onSendNotification}>
+        send notif
+      </button>
+      <div className="total">Total développeurs : {totalDevelopers}</div>
+    </header>
+  );
+}
+
+export default Header;

--- a/client/src/ui/components/Notification.tsx
+++ b/client/src/ui/components/Notification.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+interface NotificationProps {
+  visible: boolean;
+  message: string;
+}
+
+function Notification({ visible, message }: NotificationProps) {
+  if (!visible) return null;
+  return <div className="notification">{message}</div>;
+}
+
+export default Notification;


### PR DESCRIPTION
## Summary
- Break down monolithic UI into reusable components (Header, Board, RunSection, FreeSection, etc.)
- Introduce generic Column and DeveloperCard helpers for drag-and-drop lists
- Add notification component and simplify App composition

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b2886ece8832daa11b7b3c7018c05