### PR TITLE
Refactor UI into modular React components

### DIFF
--- a/client/src/style.css
+++ b/client/src/style.css
@@ -33,6 +33,22 @@ body {
   flex-wrap: wrap;
 }
 
+.run-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.run-section h3 {
+  text-align: center;
+}
+
+.run-columns {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
 .column {
   background: #f4f4f4;
   border-radius: 4px;

--- a/client/src/ui/App.tsx
+++ b/client/src/ui/App.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useState } from 'react';
-import { DragDropContext, Droppable, Draggable } from '@hello-pangea/dnd';
+import { DragDropContext } from '@hello-pangea/dnd';
+import Header from './components/Header';
+import Board from './components/Board/Board';
+import Notification from './Notification';
 import { useAssignments } from '../behavior/useAssignments';
-import { runCols, titles, columnClasses } from '../behavior/constants';
-import { Developer } from '../types';
 import { sendNotification, subscribeNotifications } from '../services/notificationService';
 
 function App() {
@@ -25,68 +26,17 @@ function App() {
     return <div>Loading...</div>;
   }
 
-  const renderList = (id: string, developers: Developer[]) => (
-    <Droppable droppableId={id} key={id}>
-      {(provided) => (
-        <div
-          className={id === 'free' ? columnClasses[id] : `column ${columnClasses[id]}`}
-          ref={provided.innerRef}
-          {...provided.droppableProps}
-        >
-          <div className="column-header">
-            <h3>{titles[id]}</h3>
-            <span className="badge">{developers.length}</span>
-          </div>
-          <div className="developer-list">
-            {developers.map((dev, index) => (
-              <Draggable draggableId={dev.id} index={index} key={dev.id}>
-                {(prov) => (
-                  <div
-                    className="developer-card"
-                    ref={prov.innerRef}
-                    {...prov.draggableProps}
-                    {...prov.dragHandleProps}
-                  >
-                    <div className="developer-name">👤 {dev.name}</div>
-                    <div className="developer-lead">
-                      👑 Lead: <span className="lead-badge">{dev.lead}</span>
-                    </div>
-                  </div>
-                )}
-              </Draggable>
-            ))}
-            {provided.placeholder}
-          </div>
-        </div>
-      )}
-    </Droppable>
-  );
-
   return (
     <>
-      <header className="header">
-        <div>
-          <h1>Affectation des Développeurs</h1>
-          <p>Gérez les affectations entre les équipes Build et Run</p>
-        </div>
-        <button className="notif-btn" onClick={() => sendNotification()}>
-          send notif
-        </button>
-        <div className="total">Total développeurs : {totalDevelopers}</div>
-      </header>
+      <Header totalDevelopers={totalDevelopers} onSendNotification={sendNotification} />
       <DragDropContext onDragEnd={handleDragEnd}>
-        <div className="free-section">{renderList('free', data.free)}</div>
-        <div className="board">
-          {renderList('build', data.build)}
-          {runCols.map((col) => renderList(col, data.run[col]))}
-        </div>
+        <Board data={data} />
       </DragDropContext>
       {saved && <div className="success">Sauvegarde réussie</div>}
-      {notification && (
-        <div className="notification">Modification effectuée par un autre utilisateur</div>
-      )}
+      <Notification visible={notification} />
     </>
   );
 }
 
 export default App;
+

--- a/client/src/ui/Notification.tsx
+++ b/client/src/ui/Notification.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+interface NotificationProps {
+  visible: boolean;
+}
+
+const Notification: React.FC<NotificationProps> = ({ visible }) => {
+  if (!visible) return null;
+  return (
+    <div className="notification">Modification effectuée par un autre utilisateur</div>
+  );
+};
+
+export default Notification;
+

--- a/client/src/ui/components/Board/Board.tsx
+++ b/client/src/ui/components/Board/Board.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Assignment } from '../../../types';
+import BuildColumn from './BuildColumn';
+import RunSection from './RunSection';
+import FreeSection from './FreeSection';
+
+interface BoardProps {
+  data: Assignment;
+}
+
+const Board: React.FC<BoardProps> = ({ data }) => {
+  return (
+    <>
+      <FreeSection developers={data.free} />
+      <div className="board">
+        <BuildColumn developers={data.build} />
+        <RunSection run={data.run} />
+      </div>
+    </>
+  );
+};
+
+export default Board;
+

--- a/client/src/ui/components/Board/BuildColumn.tsx
+++ b/client/src/ui/components/Board/BuildColumn.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import Column from '../Column';
+import { Developer } from '../../../types';
+import { titles, columnClasses } from '../../../behavior/constants';
+
+interface BuildColumnProps {
+  developers: Developer[];
+}
+
+const BuildColumn: React.FC<BuildColumnProps> = ({ developers }) => {
+  return (
+    <Column
+      id="build"
+      title={titles.build}
+      developers={developers}
+      className={`column ${columnClasses.build}`}
+    />
+  );
+};
+
+export default BuildColumn;
+

--- a/client/src/ui/components/Board/FreeSection.tsx
+++ b/client/src/ui/components/Board/FreeSection.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import Column from '../Column';
+import { Developer } from '../../../types';
+import { titles, columnClasses } from '../../../behavior/constants';
+
+interface FreeSectionProps {
+  developers: Developer[];
+}
+
+const FreeSection: React.FC<FreeSectionProps> = ({ developers }) => {
+  return (
+    <div className="free-section">
+      <Column
+        id="free"
+        title={titles.free}
+        developers={developers}
+        className={columnClasses.free}
+      />
+    </div>
+  );
+};
+
+export default FreeSection;
+

--- a/client/src/ui/components/Board/RunColumn.tsx
+++ b/client/src/ui/components/Board/RunColumn.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import Column from '../Column';
+import { Developer, Assignment } from '../../../types';
+import { titles, columnClasses } from '../../../behavior/constants';
+
+interface RunColumnProps {
+  id: keyof Assignment['run'];
+  developers: Developer[];
+}
+
+const RunColumn: React.FC<RunColumnProps> = ({ id, developers }) => {
+  return (
+    <Column
+      id={id}
+      title={titles[id]}
+      developers={developers}
+      className={`column ${columnClasses[id]}`}
+    />
+  );
+};
+
+export default RunColumn;
+

--- a/client/src/ui/components/Board/RunSection.tsx
+++ b/client/src/ui/components/Board/RunSection.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import RunColumn from './RunColumn';
+import { Assignment } from '../../../types';
+import { runCols } from '../../../behavior/constants';
+
+interface RunSectionProps {
+  run: Assignment['run'];
+}
+
+const RunSection: React.FC<RunSectionProps> = ({ run }) => {
+  return (
+    <div className="run-section">
+      <h3>⚙️ Run</h3>
+      <div className="run-columns">
+        {runCols.map((col) => (
+          <RunColumn key={col} id={col} developers={run[col]} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default RunSection;
+

--- a/client/src/ui/components/Board/RunSection.tsx
+++ b/client/src/ui/components/Board/RunSection.tsx
@@ -9,7 +9,7 @@ interface RunSectionProps {
 
 const RunSection: React.FC<RunSectionProps> = ({ run }) => {
   return (
-    <div className="run-section">
+    <div className="run-section" style={{ flex: runCols.length }}>
       <h3>⚙️ Run</h3>
       <div className="run-columns">
         {runCols.map((col) => (

--- a/client/src/ui/components/Column.tsx
+++ b/client/src/ui/components/Column.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Droppable } from '@hello-pangea/dnd';
+import DeveloperCard from './DeveloperCard';
+import { Developer } from '../../types';
+
+interface ColumnProps {
+  id: string;
+  title: string;
+  developers: Developer[];
+  className: string;
+}
+
+const Column: React.FC<ColumnProps> = ({ id, title, developers, className }) => {
+  return (
+    <Droppable droppableId={id} key={id}>
+      {(provided) => (
+        <div className={className} ref={provided.innerRef} {...provided.droppableProps}>
+          <div className="column-header">
+            <h3>{title}</h3>
+            <span className="badge">{developers.length}</span>
+          </div>
+          <div className="developer-list">
+            {developers.map((dev, index) => (
+              <DeveloperCard key={dev.id} developer={dev} index={index} />
+            ))}
+            {provided.placeholder}
+          </div>
+        </div>
+      )}
+    </Droppable>
+  );
+};
+
+export default Column;
+

--- a/client/src/ui/components/DeveloperCard.tsx
+++ b/client/src/ui/components/DeveloperCard.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Draggable } from '@hello-pangea/dnd';
+import { Developer } from '../../types';
+
+interface DeveloperCardProps {
+  developer: Developer;
+  index: number;
+}
+
+const DeveloperCard: React.FC<DeveloperCardProps> = ({ developer, index }) => {
+  return (
+    <Draggable draggableId={developer.id} index={index}>
+      {(provided) => (
+        <div
+          className="developer-card"
+          ref={provided.innerRef}
+          {...provided.draggableProps}
+          {...provided.dragHandleProps}
+        >
+          <div className="developer-name">👤 {developer.name}</div>
+          <div className="developer-lead">
+            👑 Lead: <span className="lead-badge">{developer.lead}</span>
+          </div>
+        </div>
+      )}
+    </Draggable>
+  );
+};
+
+export default DeveloperCard;
+

--- a/client/src/ui/components/Header.tsx
+++ b/client/src/ui/components/Header.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+interface HeaderProps {
+  totalDevelopers: number;
+  onSendNotification: () => void;
+}
+
+const Header: React.FC<HeaderProps> = ({ totalDevelopers, onSendNotification }) => {
+  return (
+    <header className="header">
+      <div>
+        <h1>Affectation des Développeurs</h1>
+        <p>Gérez les affectations entre les équipes Build et Run</p>
+      </div>
+      <button className="notif-btn" onClick={onSendNotification}>
+        send notif
+      </button>
+      <div className="total">Total développeurs : {totalDevelopers}</div>
+    </header>
+  );
+};
+
+export default Header;
+


### PR DESCRIPTION
## Summary
- Split monolithic App into reusable components (Header, Board with Build/Run/Free sections, Column, DeveloperCard, Notification).
- Updated App to manage drag-and-drop context and notifications with new components.

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b2cc8b8d4832d88f6a726c87aab4f