### PR TITLE
Fix developer card width consistency

### DIFF
--- a/client/src/style.css
+++ b/client/src/style.css
@@ -104,17 +104,7 @@ body {
 .developer-list {
   display: grid;
   gap: 0.5rem;
-}
-
-.build-column .developer-list,
-.anomalies-column .developer-list,
-.service-column .developer-list,
-.fastTrack-column .developer-list {
-  grid-template-columns: repeat(2, 1fr);
-}
-
-.free-column .developer-list {
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
 }
 
 .developer-card {
@@ -122,20 +112,7 @@ body {
   border: 1px solid #ccc;
   border-radius: 4px;
   padding: 0.5rem;
-  width: 90%;
-}
-
-@media (max-width: 600px) {
-  .build-column .developer-list,
-  .anomalies-column .developer-list,
-  .service-column .developer-list,
-  .fastTrack-column .developer-list {
-    grid-template-columns: 1fr;
-  }
-
-  .free-column .developer-list {
-    grid-template-columns: repeat(2, 1fr);
-  }
+  width: 100%;
 }
 
 .lead-badge {


### PR DESCRIPTION
## Summary
- Ensure developer cards use a uniform grid layout across sections
- Expand card width to fill grid cells for consistent sizing

## Testing
- `cd client && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b346c7dac832d93fd104ac2824d3d