### PR TITLE
fix: keep card when dropped in same column

### DIFF
--- a/client/src/behavior/useAssignments.ts
+++ b/client/src/behavior/useAssignments.ts
@@ -23,12 +23,16 @@ export const useAssignments = () => {
         : sourceId === 'free'
         ? [...data.free]
         : [...data.run[sourceId]];
-    const destList =
+    let destList =
       destId === 'build'
         ? [...data.build]
         : destId === 'free'
         ? [...data.free]
         : [...data.run[destId]];
+
+    if (sourceId === destId) {
+      destList = sourceList;
+    }
 
     const [moved] = sourceList.splice(result.source.index, 1);
     destList.splice(result.destination.index, 0, moved);


### PR DESCRIPTION
## Summary
- keep same column drag-and-drop from removing the card

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b455a8ce4832d9f69042db1cb34ef