### PR TITLE
feat: add developer notes

### DIFF
--- a/client/src/behavior/useAssignments.ts
+++ b/client/src/behavior/useAssignments.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { DropResult } from '@hello-pangea/dnd';
-import { Assignment } from '../types';
+import { Assignment, Developer } from '../types';
 import { getAssignments, saveAssignments } from '../services/assignmentService';
 import { sendNotification } from '../services/notificationService';
 import features from '../config';
@@ -76,6 +76,27 @@ export const useAssignments = () => {
     });
   };
 
+  const updateNote = (id: string, note?: string) => {
+    if (!data || features.readOnly) return;
+    const update = (list: Developer[]) =>
+      list.map((dev) => (dev.id === id ? { ...dev, note } : dev));
+    const newData: Assignment = {
+      build: update(data.build),
+      run: {
+        anomalies: update(data.run.anomalies),
+        service: update(data.run.service),
+        fastTrack: update(data.run.fastTrack),
+      },
+      free: update(data.free),
+    };
+    setData(newData);
+    saveAssignments(newData).then(() => {
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+      sendNotification();
+    });
+  };
+
   const totalDevelopers =
     data
       ? data.build.length +
@@ -85,5 +106,5 @@ export const useAssignments = () => {
         data.free.length
       : 0;
 
-  return { data, saved, handleDragEnd, totalDevelopers };
+  return { data, saved, handleDragEnd, totalDevelopers, updateNote };
 };

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -2,6 +2,7 @@ export type Developer = {
   id: string;
   name: string;
   lead: string;
+  note?: string;
 };
 
 export type Assignment = {

--- a/client/src/ui/App.tsx
+++ b/client/src/ui/App.tsx
@@ -16,7 +16,7 @@ import { Assignment } from '../types';
 import './App.css';
 
 function App() {
-  const { data, saved, handleDragEnd } = useAssignments();
+  const { data, saved, handleDragEnd, updateNote } = useAssignments();
   const [notification, setNotification] = useState(false);
   const [snapshots, setSnapshots] = useState<string[]>([]);
   const [view, setView] = useState<'current' | string>('current');
@@ -107,7 +107,7 @@ function App() {
         currentView={view}
       />
       <DragDropContext onDragEnd={features.dragAndDrop ? handleDragEnd : () => {}}>
-        <Board data={displayedData} />
+        <Board data={displayedData} onNoteChange={updateNote} />
       </DragDropContext>
       {view === 'current' && saved && <div className="success">Sauvegarde réussie</div>}
       <Notification visible={notification} />

--- a/client/src/ui/components/Board/Board.tsx
+++ b/client/src/ui/components/Board/Board.tsx
@@ -7,15 +7,16 @@ import FreeSection from './FreeSection';
 
 interface BoardProps {
   data: Assignment;
+  onNoteChange: (id: string, note?: string) => void;
 }
 
-const Board: React.FC<BoardProps> = ({ data }) => {
+const Board: React.FC<BoardProps> = ({ data, onNoteChange }) => {
   return (
     <>
-      <FreeSection developers={data.free} />
+      <FreeSection developers={data.free} onNoteChange={onNoteChange} />
       <div className="board">
-        <BuildColumn developers={data.build} />
-        <RunSection run={data.run} />
+        <BuildColumn developers={data.build} onNoteChange={onNoteChange} />
+        <RunSection run={data.run} onNoteChange={onNoteChange} />
       </div>
     </>
   );

--- a/client/src/ui/components/Board/BuildColumn.tsx
+++ b/client/src/ui/components/Board/BuildColumn.tsx
@@ -6,15 +6,17 @@ import { titles, columnClasses } from '../../../behavior/constants';
 
 interface BuildColumnProps {
   developers: Developer[];
+  onNoteChange: (id: string, note?: string) => void;
 }
 
-const BuildColumn: React.FC<BuildColumnProps> = ({ developers }) => {
+const BuildColumn: React.FC<BuildColumnProps> = ({ developers, onNoteChange }) => {
   return (
     <Column
       id="build"
       title={titles.build}
       developers={developers}
       className={`column ${columnClasses.build}`}
+      onNoteChange={onNoteChange}
     />
   );
 };

--- a/client/src/ui/components/Board/FreeSection.tsx
+++ b/client/src/ui/components/Board/FreeSection.tsx
@@ -6,9 +6,10 @@ import { titles, columnClasses } from '../../../behavior/constants';
 
 interface FreeSectionProps {
   developers: Developer[];
+  onNoteChange: (id: string, note?: string) => void;
 }
 
-const FreeSection: React.FC<FreeSectionProps> = ({ developers }) => {
+const FreeSection: React.FC<FreeSectionProps> = ({ developers, onNoteChange }) => {
   return (
     <div className="free-section">
       <Column
@@ -16,6 +17,7 @@ const FreeSection: React.FC<FreeSectionProps> = ({ developers }) => {
         title={titles.free}
         developers={developers}
         className={columnClasses.free}
+        onNoteChange={onNoteChange}
       />
     </div>
   );

--- a/client/src/ui/components/Board/RunColumn.tsx
+++ b/client/src/ui/components/Board/RunColumn.tsx
@@ -7,15 +7,17 @@ import { titles, columnClasses } from '../../../behavior/constants';
 interface RunColumnProps {
   id: keyof Assignment['run'];
   developers: Developer[];
+  onNoteChange: (id: string, note?: string) => void;
 }
 
-const RunColumn: React.FC<RunColumnProps> = ({ id, developers }) => {
+const RunColumn: React.FC<RunColumnProps> = ({ id, developers, onNoteChange }) => {
   return (
     <Column
       id={id}
       title={titles[id]}
       developers={developers}
       className={`column ${columnClasses[id]}`}
+      onNoteChange={onNoteChange}
     />
   );
 };

--- a/client/src/ui/components/Board/RunSection.tsx
+++ b/client/src/ui/components/Board/RunSection.tsx
@@ -6,15 +6,21 @@ import { runCols } from '../../../behavior/constants';
 
 interface RunSectionProps {
   run: Assignment['run'];
+  onNoteChange: (id: string, note?: string) => void;
 }
 
-const RunSection: React.FC<RunSectionProps> = ({ run }) => {
+const RunSection: React.FC<RunSectionProps> = ({ run, onNoteChange }) => {
   return (
     <div className="run-section" style={{ flex: runCols.length }}>
       <h3>⚙️ Run</h3>
       <div className="run-columns">
         {runCols.map((col) => (
-          <RunColumn key={col} id={col} developers={run[col]} />
+          <RunColumn
+            key={col}
+            id={col}
+            developers={run[col]}
+            onNoteChange={onNoteChange}
+          />
         ))}
       </div>
     </div>

--- a/client/src/ui/components/Column.tsx
+++ b/client/src/ui/components/Column.tsx
@@ -10,9 +10,16 @@ interface ColumnProps {
   title: string;
   developers: Developer[];
   className: string;
+  onNoteChange: (id: string, note?: string) => void;
 }
 
-const Column: React.FC<ColumnProps> = ({ id, title, developers, className }) => {
+const Column: React.FC<ColumnProps> = ({
+  id,
+  title,
+  developers,
+  className,
+  onNoteChange,
+}) => {
   return (
     <Droppable droppableId={id} key={id} isDropDisabled={!features.dragAndDrop}>
       {(provided) => (
@@ -23,7 +30,12 @@ const Column: React.FC<ColumnProps> = ({ id, title, developers, className }) => 
           </div>
           <div className="developer-list">
             {developers.map((dev, index) => (
-              <DeveloperCard key={dev.id} developer={dev} index={index} />
+              <DeveloperCard
+                key={dev.id}
+                developer={dev}
+                index={index}
+                onNoteChange={onNoteChange}
+              />
             ))}
             {provided.placeholder}
           </div>

--- a/client/src/ui/components/DeveloperCard.css
+++ b/client/src/ui/components/DeveloperCard.css
@@ -15,3 +15,26 @@
   margin-left: 4px;
   font-size: 0.75rem;
 }
+
+.developer-note {
+  background: #fffbcc;
+  padding: 2px 4px;
+  border-radius: 4px;
+  margin-top: 4px;
+}
+
+.note-btn {
+  margin-top: 4px;
+  border: none;
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.note-btn.add {
+  background: #e0e0e0;
+}
+
+.note-btn.edit {
+  background: #cce5ff;
+}

--- a/client/src/ui/components/DeveloperCard.tsx
+++ b/client/src/ui/components/DeveloperCard.tsx
@@ -7,9 +7,21 @@ import features from '../../config';
 interface DeveloperCardProps {
   developer: Developer;
   index: number;
+  onNoteChange: (id: string, note?: string) => void;
 }
 
-const DeveloperCard: React.FC<DeveloperCardProps> = ({ developer, index }) => {
+const DeveloperCard: React.FC<DeveloperCardProps> = ({
+  developer,
+  index,
+  onNoteChange,
+}) => {
+  const handleNoteClick = () => {
+    const input = prompt('Note ?', developer.note || '');
+    if (input === null) return;
+    const text = input.slice(0, 100);
+    onNoteChange(developer.id, text || undefined);
+  };
+
   return (
     <Draggable draggableId={developer.id} index={index} isDragDisabled={!features.dragAndDrop}>
       {(provided) => (
@@ -23,6 +35,17 @@ const DeveloperCard: React.FC<DeveloperCardProps> = ({ developer, index }) => {
           <div className="developer-lead">
             👑 Lead: <span className="lead-badge">{developer.lead}</span>
           </div>
+          {developer.note && (
+            <div className="developer-note">{developer.note}</div>
+          )}
+          {!features.readOnly && (
+            <button
+              className={`note-btn ${developer.note ? 'edit' : 'add'}`}
+              onClick={handleNoteClick}
+            >
+              {developer.note ? '✏️' : '+'}
+            </button>
+          )}
         </div>
       )}
     </Draggable>


### PR DESCRIPTION
## Summary
- add optional note property to Developer type
- allow adding/editing a single note per developer with max 100 characters
- display notes beneath lead info with add/edit controls

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5ee9e5044832d832d99684bfc7174